### PR TITLE
Enhance design consistency across pages by updating text colors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 <footer class="border-t border-gray-100 py-10">
-  <div class="max-w-4xl mx-auto px-6 text-center text-sm text-gray-400">
+  <div class="max-w-4xl mx-auto px-6 text-center text-sm text-gray-500">
     <p>&copy; {new Date().getFullYear()} Tatsuro Shibamura. All rights reserved.</p>
-    <a href="/privacypolicy/" class="hover:text-gray-600 transition-colors mt-1 inline-block">
+    <a href="/privacypolicy/" class="hover:text-gray-900 transition-colors mt-1 inline-block">
       Privacy Policy
     </a>
   </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,9 +5,9 @@ import Footer from '../components/Footer.astro';
 
 <Base title="404 - Page Not Found">
   <main class="max-w-4xl mx-auto px-6 pt-32 pb-16 text-center min-h-[70vh] flex flex-col items-center justify-center">
-    <h1 class="text-7xl font-bold text-gray-200">404</h1>
-    <p class="mt-4 text-xl text-gray-600">Page Not Found</p>
-    <p class="mt-2 text-sm text-gray-400">The page you're looking for doesn't exist or has been moved.</p>
+    <h1 class="text-7xl font-bold text-gray-300">404</h1>
+    <p class="mt-4 text-xl text-gray-700">Page Not Found</p>
+    <p class="mt-2 text-sm text-gray-500">The page you're looking for doesn't exist or has been moved.</p>
     <a
       href="/"
       class="mt-8 inline-block px-6 py-2.5 text-sm font-medium text-white bg-gray-900 rounded-lg hover:bg-gray-700 transition-colors"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -140,14 +140,14 @@ const expertise = [
           <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-white mb-1 drop-shadow-lg">
             Tatsuro Shibamura
           </h1>
-          <p class="text-white/80 text-base sm:text-lg drop-shadow-md">
+          <p class="text-white/90 text-base sm:text-lg drop-shadow-md">
             Software Engineer / Founder of <a href="https://polymind.jp" target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 hover:text-white transition-colors">Polymind</a> / Microsoft MVP for Azure
           </p>
         </div>
       </div>
-      <p class="text-gray-400 text-sm max-w-xl mx-auto mt-4 leading-relaxed">
+      <p class="text-gray-600 text-sm max-w-2xl mx-auto mt-4 leading-relaxed">
         Cloud-native development and Azure infrastructure specialist with 15+ years of experience.
-        Founder of <a href="https://polymind.jp" target="_blank" rel="noopener noreferrer" class="text-gray-300 hover:text-white underline underline-offset-2 transition-colors">Polymind</a>.
+        Founder of <a href="https://polymind.jp" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-gray-900 underline underline-offset-2 transition-colors">Polymind</a>.
         Actively contributing to the developer community through technical writing, open-source projects,
         and conference presentations as a long-tenured Microsoft MVP.
       </p>
@@ -179,8 +179,8 @@ const expertise = [
     <!-- Awards -->
     <section class="mb-20">
       <div class="mb-8">
-        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-400">Awards</h2>
-        <p class="text-xs text-gray-400 mt-1">Recognized by Microsoft for contributions to the developer community since 2011.</p>
+        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-600">Awards</h2>
+        <p class="text-xs text-gray-600 mt-1">Recognized by Microsoft for contributions to the developer community since 2011.</p>
       </div>
       <div class="space-y-6">
         {awards.map((award) => (
@@ -198,7 +198,7 @@ const expertise = [
               {award.entries.map((entry, i) => (
                 <div class:list={[i > 0 && 'pt-2 border-t border-gray-200/60']}>
                   <p class="font-medium text-gray-900 text-sm leading-snug">{entry.title}</p>
-                  <p class="text-xs text-gray-400 mt-0.5">{entry.period}</p>
+                  <p class="text-xs text-gray-600 mt-0.5">{entry.period}</p>
                 </div>
               ))}
             </div>
@@ -210,8 +210,8 @@ const expertise = [
     <!-- Open Source -->
     <section class="mb-20">
       <div class="mb-8">
-        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-400">Open Source</h2>
-        <p class="text-xs text-gray-400 mt-1">Notable projects I actively maintain as open source contributions.</p>
+        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-600">Open Source</h2>
+        <p class="text-xs text-gray-600 mt-1">Notable projects I actively maintain as open source contributions.</p>
       </div>
       <div class="space-y-4">
         {ossProjects.map((project) => (
@@ -226,15 +226,15 @@ const expertise = [
                 <div class="flex items-center gap-2">
                   <svg class="w-4 h-4 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>
                   <p class="text-sm font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">{project.name}</p>
-                  <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 font-medium">
+                  <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-600 font-medium">
                     <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                     {project.stars}
                   </span>
                 </div>
-                <p class="text-xs text-gray-500 mt-1.5 leading-relaxed">{project.description}</p>
+                <p class="text-xs text-gray-700 mt-1.5 leading-relaxed">{project.description}</p>
                 <div class="flex flex-wrap gap-1.5 mt-3">
                   {project.tags.map((tag) => (
-                    <span class="px-2 py-0.5 rounded-md bg-gray-100 text-[10px] font-medium text-gray-500">{tag}</span>
+                    <span class="px-2 py-0.5 rounded-md bg-gray-100 text-[10px] font-medium text-gray-700">{tag}</span>
                   ))}
                 </div>
               </div>
@@ -248,8 +248,8 @@ const expertise = [
     <!-- Certifications -->
     <section class="mb-20">
       <div class="mb-8">
-        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-400">Certifications</h2>
-        <p class="text-xs text-gray-400 mt-1">Professional certifications validating cloud and DevOps expertise.</p>
+        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-600">Certifications</h2>
+        <p class="text-xs text-gray-600 mt-1">Professional certifications validating cloud and DevOps expertise.</p>
       </div>
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
         {certifications.map((cert) => (
@@ -262,7 +262,7 @@ const expertise = [
             <Image src={cert.img} alt={cert.name} class="w-16 h-16 object-contain group-hover:scale-105 transition-transform" width={64} height={64} />
             <div class="text-center">
               <p class="text-xs font-medium text-gray-700 leading-tight">{cert.name}</p>
-              {cert.level && <p class="text-[10px] text-gray-400 mt-0.5">{cert.level}</p>}
+              {cert.level && <p class="text-[10px] text-gray-600 mt-0.5">{cert.level}</p>}
             </div>
           </a>
         ))}
@@ -272,8 +272,8 @@ const expertise = [
     <!-- Connect -->
     <section class="mb-8">
       <div class="mb-8">
-        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-400">Connect</h2>
-        <p class="text-xs text-gray-400 mt-1">Find me on these platforms — feel free to reach out.</p>
+        <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-600">Connect</h2>
+        <p class="text-xs text-gray-600 mt-1">Find me on these platforms — feel free to reach out.</p>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {connections.map((conn) => (
@@ -290,7 +290,7 @@ const expertise = [
             )}
             <div class="min-w-0">
               <p class="text-sm font-medium text-gray-900">{conn.label}</p>
-              <p class="text-xs text-gray-400 truncate">{conn.handle}</p>
+              <p class="text-xs text-gray-600 truncate">{conn.handle}</p>
             </div>
             <svg class="w-4 h-4 text-gray-300 ml-auto shrink-0 group-hover:text-gray-500 group-hover:translate-x-0.5 transition-all" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
           </a>

--- a/src/pages/privacypolicy/index.astro
+++ b/src/pages/privacypolicy/index.astro
@@ -5,7 +5,7 @@ import Footer from '../../components/Footer.astro';
 
 <Base title="Privacy Policy - Tatsuro Shibamura">
   <main class="max-w-3xl mx-auto px-6 pt-10 pb-8">
-    <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-gray-900 transition-colors mb-8">
+    <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 transition-colors mb-8">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
       Home
     </a>
@@ -13,10 +13,10 @@ import Footer from '../../components/Footer.astro';
 
     <div class="prose prose-gray max-w-none">
       <h2 class="text-xl font-semibold text-gray-900 mt-8 mb-4">Windows Store apps Privacy policy</h2>
-      <p class="text-gray-600 leading-relaxed mb-4">
+      <p class="text-gray-700 leading-relaxed mb-4">
         This document applies to all applications. Please refer to the description of the application for the specific conditions for each application.
       </p>
-      <ul class="space-y-4 text-gray-600">
+      <ul class="space-y-4 text-gray-700">
         <li>
           <strong class="text-gray-900">Personal Information</strong>
           <p class="mt-1">It does not, without the permission of the user, and obtain personal information, saving, or sending the application.</p>

--- a/src/pages/slides/index.astro
+++ b/src/pages/slides/index.astro
@@ -42,12 +42,12 @@ const presentations = [
 
 <Base title="Presentations - Tatsuro Shibamura">
   <main class="max-w-3xl mx-auto px-6 pt-10 pb-8">
-    <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-gray-900 transition-colors mb-8">
+    <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 transition-colors mb-8">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
       Home
     </a>
     <h1 class="text-3xl font-bold tracking-tight text-gray-900 mb-2">Presentations</h1>
-    <p class="text-gray-400 text-sm mb-12">Conference talks and community presentations on Azure, .NET, and cloud-native topics.</p>
+    <p class="text-gray-600 text-sm mb-12">Conference talks and community presentations on Azure, .NET, and cloud-native topics.</p>
 
     {presentations.map((group) => (
       <div class="mb-12">
@@ -57,7 +57,7 @@ const presentations = [
         <div class="space-y-8">
           {group.talks.map((talk) => (
             <div>
-              <h3 class="text-base font-medium text-gray-700 mb-3">{talk.title}</h3>
+              <h3 class="text-base font-medium text-gray-900 mb-3">{talk.title}</h3>
               <Slide src={`/slides/${talk.id}/`} />
             </div>
           ))}


### PR DESCRIPTION
This pull request updates the color palette across several pages and components to improve readability and visual consistency. The main changes involve shifting various text and UI element colors from lighter gray shades to slightly darker or more contrasting grays, enhancing accessibility and clarity throughout the site.

**Sitewide color palette and accessibility improvements:**

- Updated text and UI element colors in the main profile (`index.astro`) to use darker and more consistent gray shades, improving readability for section headings, descriptions, awards, open source projects, certifications, and contact information. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L143-R150) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L182-R183) [[3]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L201-R201) [[4]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L213-R214) [[5]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L229-R237) [[6]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L251-R252) [[7]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L265-R265) [[8]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L275-R276) [[9]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L293-R293)
- Refined the 404 page (`404.astro`) color usage for headings and descriptions, making error messages and supporting text more legible.
- Improved the footer (`Footer.astro`) by using darker gray text and a bolder hover state for the privacy policy link.

**Consistency in navigation and secondary pages:**

- Adjusted link and text colors on the Privacy Policy page (`privacypolicy/index.astro`) for better contrast and consistency with the rest of the site.
- Updated the Presentations page (`slides/index.astro`) to use darker text for navigation links, section descriptions, and presentation titles, aligning with the new color scheme. [[1]](diffhunk://#diff-6f88006b80449cefd5f34d20ad9eb42a0b06382ed54bbd8d3f544772148a0801L45-R50) [[2]](diffhunk://#diff-6f88006b80449cefd5f34d20ad9eb42a0b06382ed54bbd8d3f544772148a0801L60-R60)