### PR TITLE
Add JSON-LD structured data to all pages

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -5,16 +5,22 @@ interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
+  jsonLd?: object | object[];
 }
 
 const {
   title = 'Tatsuro Shibamura | Azure Specialist, OSS & Tech Blog',
   description = 'Software Engineer and Microsoft MVP for Azure. Cloud-native development, open-source projects, and technical community contributions.',
   ogImage = '/ogp.png',
+  jsonLd,
 } = Astro.props;
 
 const ogImageUrl = new URL(ogImage, Astro.site!).href;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site!).href;
+
+const structuredData = jsonLd
+  ? JSON.stringify(Array.isArray(jsonLd) ? jsonLd : [jsonLd])
+  : null;
 ---
 
 <!doctype html>
@@ -43,6 +49,10 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site!).href;
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
     <meta name="twitter:site" content="@shibayan" />
+
+    {structuredData && (
+      <script type="application/ld+json" is:inline set:html={structuredData} />
+    )}
   </head>
   <body class="bg-white text-gray-900 antialiased">
     <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,9 +103,70 @@ const expertise = [
   { label: 'Windows on Arm', color: 'bg-amber-50 text-amber-700' },
   { label: 'Open Source', color: 'bg-rose-50 text-rose-700' },
 ];
+
+const personId = new URL('#person', Astro.site!).href;
+const websiteId = new URL('#website', Astro.site!).href;
+const avatarUrl = new URL(avatarJpg.src, Astro.site!).href;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': websiteId,
+      url: Astro.site!.href,
+      name: 'shibayan.jp',
+      description:
+        'Profile site of Tatsuro Shibamura — Software Engineer and Microsoft MVP for Azure.',
+      inLanguage: 'en',
+      publisher: { '@id': personId },
+    },
+    {
+      '@type': 'ProfilePage',
+      '@id': new URL('#webpage', Astro.site!).href,
+      url: Astro.site!.href,
+      name: 'Tatsuro Shibamura | Azure Specialist, OSS & Tech Blog',
+      isPartOf: { '@id': websiteId },
+      about: { '@id': personId },
+      mainEntity: { '@id': personId },
+      inLanguage: 'en',
+    },
+    {
+      '@type': 'Person',
+      '@id': personId,
+      name: 'Tatsuro Shibamura',
+      alternateName: 'shibayan',
+      url: Astro.site!.href,
+      image: avatarUrl,
+      email: 'me@shibayan.jp',
+      jobTitle: 'Software Engineer',
+      description:
+        'Cloud-native development and Azure infrastructure specialist with 15+ years of experience. Founder of Polymind and a long-tenured Microsoft MVP for Azure.',
+      worksFor: {
+        '@type': 'Organization',
+        name: 'Polymind',
+        url: 'https://polymind.jp',
+      },
+      knowsAbout: [
+        'Microsoft Azure',
+        'Cloud Native',
+        'ASP.NET',
+        'C#',
+        '.NET',
+        'Windows on Arm',
+        'Open Source Software',
+        'DevOps',
+      ],
+      award: awards.flatMap((award) => award.entries.map((entry) => entry.title)),
+      sameAs: connections
+        .filter((conn) => !conn.url.startsWith('mailto:'))
+        .map((conn) => conn.url),
+    },
+  ],
+};
 ---
 
-<Base>
+<Base jsonLd={jsonLd}>
   <main class="max-w-4xl mx-auto px-6 sm:pt-4 pb-12">
     <!-- Hero with overlay -->
     <section class="text-center mb-24">

--- a/src/pages/privacypolicy/index.astro
+++ b/src/pages/privacypolicy/index.astro
@@ -1,9 +1,32 @@
 ---
 import Base from '../../layouts/Base.astro';
 import Footer from '../../components/Footer.astro';
+
+const pageUrl = new URL('/privacypolicy/', Astro.site!).href;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: Astro.site!.href },
+        { '@type': 'ListItem', position: 2, name: 'Privacy Policy', item: pageUrl },
+      ],
+    },
+    {
+      '@type': 'WebPage',
+      '@id': pageUrl,
+      url: pageUrl,
+      name: 'Privacy Policy - Tatsuro Shibamura',
+      inLanguage: 'en',
+      isPartOf: { '@id': new URL('#website', Astro.site!).href },
+    },
+  ],
+};
 ---
 
-<Base title="Privacy Policy - Tatsuro Shibamura">
+<Base title="Privacy Policy - Tatsuro Shibamura" jsonLd={jsonLd}>
   <main class="max-w-3xl mx-auto px-6 pt-10 pb-8">
     <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 transition-colors mb-8">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>

--- a/src/pages/slides/index.astro
+++ b/src/pages/slides/index.astro
@@ -38,9 +38,46 @@ const presentations = [
     ],
   },
 ];
+
+const pageUrl = new URL('/slides/', Astro.site!).href;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: Astro.site!.href },
+        { '@type': 'ListItem', position: 2, name: 'Presentations', item: pageUrl },
+      ],
+    },
+    {
+      '@type': 'CollectionPage',
+      '@id': pageUrl,
+      url: pageUrl,
+      name: 'Presentations - Tatsuro Shibamura',
+      description:
+        'Conference talks and community presentations on Azure, .NET, and cloud-native topics.',
+      inLanguage: 'en',
+      isPartOf: { '@id': new URL('#website', Astro.site!).href },
+      about: { '@id': new URL('#person', Astro.site!).href },
+      mainEntity: {
+        '@type': 'ItemList',
+        itemListElement: presentations
+          .flatMap((group) => group.talks)
+          .map((talk, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: talk.title,
+            url: new URL(`/slides/${talk.id}/`, Astro.site!).href,
+          })),
+      },
+    },
+  ],
+};
 ---
 
-<Base title="Presentations - Tatsuro Shibamura">
+<Base title="Presentations - Tatsuro Shibamura" jsonLd={jsonLd}>
   <main class="max-w-3xl mx-auto px-6 pt-10 pb-8">
     <a href="/" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 transition-colors mb-8">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>


### PR DESCRIPTION
## What

Adds Schema.org structured data (JSON-LD) across the site.

- **Base layout**: new `jsonLd` prop that renders an `application/ld+json` script in `<head>` (accepts a single object or an array).
- **Home** (`index.astro`): `@graph` with `WebSite` / `ProfilePage` / `Person`, where `Person` is the main entity.
- **Presentations** (`slides/index.astro`): `BreadcrumbList` + `CollectionPage` with all talks as an `ItemList`.
- **Privacy Policy**: `BreadcrumbList` + `WebPage`.

## Why

Structured data helps search engines understand the site as a personal profile and connect the author identity (MVP awards, SNS profiles via `sameAs`, employer, areas of expertise), improving rich-result eligibility and SEO.

## Notes for reviewers

- `sameAs`, `award`, and the talk list are derived from the existing `connections` / `awards` / `presentations` arrays, so they stay in sync automatically.
- Pages are linked via `@id` (`#website` / `#person`) so Google resolves them to a single site/person entity.
- CSP (`security.csp` in `astro.config.mjs`) is unaffected: `application/ld+json` is a non-executable data block, not subject to `script-src`. Verified in the build output.
- `Person.image` currently points to the hashed build asset path (`/_astro/avatar.*.jpg`), which is valid per build.

Validate after deploy with the [Rich Results Test](https://search.google.com/test/rich-results) and [Schema Validator](https://validator.schema.org/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)