### PR TITLE
Update MVP period from 2026 to 2027 in awards section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ const awards = [
     badge: mvpBadge,
     url: 'https://mvp.microsoft.com/en-US/mvp/profile/e1ba70c0-3c9a-e411-93f2-9cb65495d3c4',
     entries: [
-      { title: 'Microsoft MVP for Microsoft Azure', period: '2018 - 2026' },
+      { title: 'Microsoft MVP for Microsoft Azure', period: '2018 - 2027' },
       { title: 'Microsoft MVP for Visual Studio and Development Technologies', period: '2015 - 2018' },
       { title: 'Microsoft MVP for ASP.NET/IIS', period: '2011 - 2015' },
     ],


### PR DESCRIPTION
This pull request updates the Microsoft MVP award period in the `src/pages/index.astro` file.

- Content update:
  * Extended the period for the "Microsoft MVP for Microsoft Azure" award from "2018 - 2026" to "2018 - 2027" in the `awards` array.